### PR TITLE
Fix - [0.101][SEVERE]: Failed to create /home/seleuser/.pki/nssdb directory.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,6 @@ RUN apt-get install -y -q \
   xfonts-cyrillic
 RUN useradd -d /home/seleuser -m seleuser
 RUN mkdir -p /home/seleuser/chrome
-#RUN mkdir -p /home/seleuser/.pki/nssdb
 RUN chown -R seleuser /home/seleuser
 RUN chgrp -R seleuser /home/seleuser
 # fix https://code.google.com/p/chromium/issues/detail?id=318548


### PR DESCRIPTION
I was getting this error when running the container and trying to create a new Chrome session. My code would get to here:
`WebDriver driver = new RemoteWebDriver(new URL("http://192.168.59.103:4444/wd/hub"), capabilities);`
and then timeout after 60 seconds. I started the container and attached and this error showed up in the output.
[0.101][SEVERE]: Failed to create /home/seleuser/.pki/nssdb directory.

Changing the chown and chgrp commands to recursive fixes it for me.
